### PR TITLE
Bugfix/2.0.1

### DIFF
--- a/core.py
+++ b/core.py
@@ -3075,7 +3075,7 @@ def _create_operation_node(operation, *args):
 
     # Set operation attr if specified in OPERATORS for this node-type
     node_operation = OPERATORS[operation].get("operation", None)
-    if node_operation:
+    if node_operation is not None:
         _unravel_and_set_or_connect_a_to_b(
             "{0}.operation".format(new_node), node_operation
         )

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,15 @@
 Changes
 ==============================================================================
 
+Release 2.0.1
+*************
+
+Bugs fixed
+----------
+* Aliased attributes can now be accessed (om_util.get_mplug_of_mobj couldn't find them before)
+* Operation values of zero are now set correctly (they were ignored)
+
+
 Release 2.0.0
 *************
 
@@ -46,6 +55,7 @@ Testing
 
 Features removed
 ----------------
+
 
 Release 1.0.0
 *************

--- a/om_util.py
+++ b/om_util.py
@@ -600,6 +600,13 @@ def get_mplug_of_mobj(mobj, attr):
         # findPlug-flags: (attr, wantNetworkedPlug)
         mplug = node_mfn_dep_node.findPlug(attr, False)
 
+    # Check for aliased plugs, if none was found yet.
+    if not mplug:
+        alias_list = node_mfn_dep_node.getAliasList()
+        for alias, attr_name in alias_list:
+            if attr == alias:
+                mplug = get_mplug_of_mobj(mobj, attr_name)
+
     return mplug
 
 


### PR DESCRIPTION
Issues fixed:
* Aliased attributes can now be accessed (om_util.get_mplug_of_mobj couldn't find them before)
* Operation values of zero are now set correctly (they were ignored)